### PR TITLE
Change class fields to abstracted version of IO implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ hs_err_pid*
 replay_pid*
 .gradle/
 build/
+
+# IntelliJ IDEA
+.idea/*

--- a/src/main/java/frc/robot/subsystems/indexer/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/Indexer.java
@@ -7,7 +7,8 @@ import edu.wpi.first.wpilibj.DigitalInput;
 
 public class Indexer extends SpikeSystem<IndexerIO.IndexerIOInputs> {
     private final static double indexerSpeed = 10.0; // Rotations per second
-    private final IndexerIOTalonFX indexerIO = new IndexerIOTalonFX();
+
+    private IndexerIO indexerIO;
     private DigitalInput proximitySensor;
 
     public Indexer(int channel) {
@@ -27,6 +28,7 @@ public class Indexer extends SpikeSystem<IndexerIO.IndexerIOInputs> {
 
     @Override
     protected Runnable setupDataRefresher() {
+        this.indexerIO = new IndexerIOTalonFX();
         return useAsyncDataRefresher(indexerIO);
     }
 }

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
@@ -2,9 +2,10 @@ package frc.robot.subsystems.indexer;
 
 import frc.lib.subsystem.BaseIO;
 import frc.lib.subsystem.BaseInputClass;
+import frc.lib.subsystem.IORefresher;
 import org.littletonrobotics.junction.AutoLog;
 
-public interface IndexerIO extends BaseIO<IndexerIO.IndexerIOInputs> {
+public interface IndexerIO extends BaseIO<IndexerIO.IndexerIOInputs>, IORefresher {
 
     @AutoLog
     public static class IndexerIOInputs extends BaseInputClass {

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -17,7 +17,7 @@ public class Intake extends SpikeSystem<IntakeIO.IntakeIOInputs> {
         DEPLOYED, RETRACTED, DEPLOYING, RETRACTING
     }
 
-    private IntakeIOTalonFX intakeIO;
+    private IntakeIO intakeIO;
     private final CommandSwerveDrivetrain drivetrain;
 
     private boolean running = false; // True if the intake is running, False otherwise
@@ -142,7 +142,7 @@ public class Intake extends SpikeSystem<IntakeIO.IntakeIOInputs> {
 
     @Override
     protected Runnable setupDataRefresher() {
-        intakeIO = new IntakeIOTalonFX();
+        this.intakeIO = new IntakeIOTalonFX();
         return useAsyncDataRefresher(intakeIO);
     }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -2,11 +2,12 @@ package frc.robot.subsystems.intake;
 
 import frc.lib.subsystem.BaseIO;
 import frc.lib.subsystem.BaseInputClass;
+import frc.lib.subsystem.IORefresher;
 import frc.robot.subsystems.intake.Intake.IntakeState;
 
 import org.littletonrobotics.junction.AutoLog;
 
-public interface IntakeIO extends BaseIO<IntakeIO.IntakeIOInputs> {
+public interface IntakeIO extends BaseIO<IntakeIO.IntakeIOInputs>, IORefresher {
   @AutoLog
   class IntakeIOInputs extends BaseInputClass {
     public double intakeVelocityRPS = 0.0; // Intake velocity in Rotations Per Second

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -3,14 +3,13 @@ package frc.robot.subsystems.vision;
 import frc.lib.subsystem.SpikeSystem;
 import frc.robot.subsystems.drive.CommandSwerveDrivetrain;
 import frc.robot.subsystems.vision.VisionIO.VisionIOInputs;
-import frc.robot.subsystems.vision.photon.CameraManager;
 
 import org.littletonrobotics.junction.Logger;
 import org.photonvision.EstimatedRobotPose;
 
 public class Vision extends SpikeSystem<VisionIOInputs> {
 
-    private VisionIOPhotonCamera photonCameras;
+    private VisionIO visionIO;
     private final CommandSwerveDrivetrain drive;
 
     public Vision(CommandSwerveDrivetrain drive) {
@@ -35,7 +34,7 @@ public class Vision extends SpikeSystem<VisionIOInputs> {
 
     @Override
     protected Runnable setupDataRefresher() {
-        photonCameras = new VisionIOPhotonCamera();
-        return useAsyncDataRefresher(photonCameras);
+        this.visionIO = new VisionIOPhotonCamera();
+        return useAsyncDataRefresher(visionIO);
     }
 }

--- a/src/main/java/frc/robot/subsystems/vision/VisionIO.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIO.java
@@ -2,12 +2,13 @@ package frc.robot.subsystems.vision;
 
 import frc.lib.subsystem.BaseIO;
 import frc.lib.subsystem.BaseInputClass;
+import frc.lib.subsystem.IORefresher;
 import org.littletonrobotics.junction.AutoLog;
 import org.photonvision.EstimatedRobotPose;
 
 import java.util.List;
 
-public interface VisionIO extends BaseIO<VisionIO.VisionIOInputs> {
+public interface VisionIO extends BaseIO<VisionIO.VisionIOInputs>, IORefresher {
 
     @AutoLog
     public static class VisionIOInputs extends BaseInputClass {


### PR DESCRIPTION
Right now the interfaces are not extending the IORefresher, which means they cannot be used in the useAsyncDataRefresher hook. Changing the interface to extend the IORefresher allows for the class field to be the abstracted version of the IO implementation, meaning all interaction with the implementation must be contracted through the interface.


This fixes Vision, Indexer, and Intake. 

Closes #27 