### PR TITLE
Add button mappings for driver and operator controllers

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -13,10 +13,12 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
 
+import frc.lib.SpikeController;
 import frc.robot.generated.TunerConstants;
 import frc.robot.subsystems.drive.CommandSwerveDrivetrain;
 import frc.robot.subsystems.findexer.Findexer;
@@ -45,8 +47,8 @@ public class RobotContainer {
 
     private final Telemetry logger = new Telemetry(MaxSpeed);
 
-    private final CommandXboxController driverController = new CommandXboxController(0);
-    private final CommandXboxController operatorController = new CommandXboxController(1);
+    private final CommandXboxController driverController = new SpikeController(0, 0.05);
+    private final CommandXboxController operatorController = new SpikeController(1, 0.05);
 
     public static CommandSwerveDrivetrain drive;
     private final Vision vision;
@@ -78,27 +80,34 @@ public class RobotContainer {
     }
 
     private void configureBindings() {
+        setupSwerveBindings();
+        setupIntakeBindings();
+        setupTargetingBindings();
+        setupShooterBindings();
+    }
+
+    private void setupSwerveBindings() {
         // Note that X is defined as forward according to WPILib convention,
         // and Y is defined as to the left according to WPILib convention.
         drive.setDefaultCommand(
-            // Drivetrain will execute this command periodically
-            drive.applyRequest(() ->
-                driveCmd.withVelocityX(-driverController.getLeftY() * MaxSpeed) // Drive forward with negative Y (forward)
-                    .withVelocityY(-driverController.getLeftX() * MaxSpeed) // Drive left with negative X (left)
-                    .withRotationalRate(-driverController.getRightX() * MaxAngularRate) // Drive counterclockwise with negative X (left)
-            )
+                // Drivetrain will execute this command periodically
+                drive.applyRequest(() ->
+                        driveCmd.withVelocityX(-driverController.getLeftY() * MaxSpeed) // Drive forward with negative Y (forward)
+                                .withVelocityY(-driverController.getLeftX() * MaxSpeed) // Drive left with negative X (left)
+                                .withRotationalRate(-driverController.getRightX() * MaxAngularRate) // Drive counterclockwise with negative X (left)
+                )
         );
 
         // Idle while the robot is disabled. This ensures the configured
         // neutral mode is applied to the drive motors while disabled.
         final var idle = new SwerveRequest.Idle();
         RobotModeTriggers.disabled().whileTrue(
-            drive.applyRequest(() -> idle).ignoringDisable(true)
+                drive.applyRequest(() -> idle).ignoringDisable(true)
         );
 
         driverController.a().whileTrue(drive.applyRequest(() -> brake));
         driverController.b().whileTrue(drive.applyRequest(() ->
-            point.withModuleDirection(new Rotation2d(-driverController.getLeftY(), -driverController.getLeftX()))
+                point.withModuleDirection(new Rotation2d(-driverController.getLeftY(), -driverController.getLeftX()))
         ));
 
         // Run SysId routines when holding back/start and X/Y.
@@ -110,12 +119,29 @@ public class RobotContainer {
 
         // reset the field-centric heading on left bumper press
         driverController.leftBumper().onTrue(drive.runOnce(() -> drive.seedFieldCentric()));
+    }
 
-        operatorController.a().onTrue(intake.run(() -> intake.deploy()));
-        operatorController.b().onTrue(intake.run(() -> intake.retract()));
+    private void setupIntakeBindings() {
+        // toggle intake on B press
+        operatorController.b().onTrue(Commands.runOnce(() -> {
+            if (intake.isDeployed()) {
+                intake.retract();
+            } else {
+                intake.deploy();
+            }
+        }));
+    }
 
-        operatorController.x().onTrue(targeting.run(() -> targeting.setTargetingHub()));
-        operatorController.y().onTrue(targeting.run(() -> targeting.setTargetingShuttle()));
+    private void setupTargetingBindings() {
+        operatorController.rightBumper().onTrue(targeting.run(targeting::setTargetingHub));
+        operatorController.leftBumper().onTrue(targeting.run(targeting::setTargetingShuttle));
+    }
+
+    private void setupShooterBindings() {
+        // toggle shooter on right trigger hold
+        driverController.rightTrigger()
+                .whileTrue(shooter.run(shooter::setDriverRequestingShootingTrue))
+                .whileFalse(shooter.run(shooter::setDriverRequestingShootingFalse));
     }
 
     public Command getAutonomousCommand() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -137,8 +137,8 @@ public class RobotContainer {
     private void setupShooterBindings() {
         // toggle shooter on right trigger hold
         driverController.rightTrigger()
-                .whileTrue(shooter.run(shooter::setDriverRequestingShootingTrue))
-                .whileFalse(shooter.run(shooter::setDriverRequestingShootingFalse));
+                .whileTrue(shooter.run(() -> shooter.setDriverRequestingShooting(true)))
+                .whileFalse(shooter.run(() -> shooter.setDriverRequestingShooting(false)));
     }
 
     public Command getAutonomousCommand() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -120,13 +120,7 @@ public class RobotContainer {
 
     private void setupIntakeBindings() {
         // toggle intake on B press
-        operatorController.b().onTrue(Commands.runOnce(() -> {
-            if (intake.isDeployed()) {
-                intake.retract();
-            } else {
-                intake.deploy();
-            }
-        }));
+        operatorController.b().onTrue(intake.run(intake::toggleIntake));
     }
 
     private void setupTargetingBindings() {

--- a/src/main/java/frc/robot/subsystems/indexer/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/Indexer.java
@@ -48,10 +48,10 @@ public class Indexer extends SpikeSystem<IndexerIO.IndexerIOInputs> {
 
     /**
      * Determines if the shooter and turret are ready to receive a ball.
-     * @return true if both the shooter is at target RPS and the turret is at target angle, false otherwise
+     * @return true if the shooter is at target RPS, the turret is at target angle, and the driver is requesting to shoot, false otherwise
      */
     private boolean mechanismReadyForBalls() {
-        return shooter.isAtTargetRPS() && turret.isAtTargetAngle();
+        return shooter.isAtTargetRPS() && turret.isAtTargetAngle() && shooter.isDriverRequestingShooting();
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -150,4 +150,13 @@ public class Intake extends SpikeSystem<IntakeIO.IntakeIOInputs> {
         this.intakeIO = new IntakeIOTalonFX();
         return useAsyncDataRefresher(intakeIO);
     }
+
+    // Toggles the intake between deployed and retracted states
+    public void toggleIntake() {
+        if (intakeIO.getIntakeState() == IntakeState.DEPLOYED || intakeIO.getIntakeState() == IntakeState.DEPLOYING) {
+            retract();
+        } else {
+            deploy();
+        }
+    }
 }

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -140,6 +140,11 @@ public class Intake extends SpikeSystem<IntakeIO.IntakeIOInputs> {
         }
     }
 
+    // Returns true if the intake is fully deployed, false otherwise
+    public boolean isDeployed() {
+        return intakeIO.getIntakeState() == IntakeState.DEPLOYED;
+    }
+
     @Override
     protected Runnable setupDataRefresher() {
         this.intakeIO = new IntakeIOTalonFX();

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -49,17 +49,11 @@ public class Shooter extends SpikeSystem<ShooterIO.ShooterIOInputs> {
     }
 
     /**
-     * Sets the driver requesting shooting to true, indicating that the driver is currently requesting to shoot. This should be called when the driver presses the shoot button.
+     * Sets whether the driver is currently requesting to shoot. This can be used to determine if the shooter should be active or not.
+      * @param isRequesting true if the driver is requesting to shoot, false otherwise
      */
-    public void setDriverRequestingShootingTrue() {
-        this.driverRequestingShooting = true;
-    }
-
-    /**
-    * Sets the driver requesting shooting to false, indicating that the driver is no longer requesting to shoot. This should be called when the driver releases the shoot button.
-    */
-    public void setDriverRequestingShootingFalse() {
-        this.driverRequestingShooting = false;
+    public void setDriverRequestingShooting(boolean isRequesting) {
+        this.driverRequestingShooting = isRequesting;
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -9,6 +9,7 @@ public class Shooter extends SpikeSystem<ShooterIO.ShooterIOInputs> {
 
     private ShooterIO shooterIO;
     private double targetRPS = 0.0; // Target rotations per second
+    private boolean driverRequestingShooting = false; // Whether the driver is currently requesting to shoot
 
     public Shooter() {
         super("Shooter", new ShooterIO.ShooterIOInputs());
@@ -45,5 +46,27 @@ public class Shooter extends SpikeSystem<ShooterIO.ShooterIOInputs> {
      */
     public boolean isAtTargetRPS() {
         return Math.abs(super.io.motorRPS - targetRPS) < SHOOTER_READY_THRESHOLD_RPS;
+    }
+
+    /**
+     * Sets the driver requesting shooting to true, indicating that the driver is currently requesting to shoot. This should be called when the driver presses the shoot button.
+     */
+    public void setDriverRequestingShootingTrue() {
+        this.driverRequestingShooting = true;
+    }
+
+    /**
+    * Sets the driver requesting shooting to false, indicating that the driver is no longer requesting to shoot. This should be called when the driver releases the shoot button.
+    */
+    public void setDriverRequestingShootingFalse() {
+        this.driverRequestingShooting = false;
+    }
+
+    /**
+     * Returns whether the driver is currently requesting to shoot.
+     * @return true if the driver is requesting to shoot, false otherwise
+     */
+    public boolean isDriverRequestingShooting() {
+        return this.driverRequestingShooting;
     }
 }


### PR DESCRIPTION
Add button mappings for the driver and operator controllers. 

Operator controller:
- Press B: Toggle intake state (deployed <--> retracted) 
- Right Bumper: Set targeting hub shooter state
- Left Bumper: Set targeting shuttle state

Driver controller:
- Hold right trigger: fire balls 